### PR TITLE
Support progressive decoding for static FLIF images.

### DIFF
--- a/Example/SDWebImageFLIFCoder/SDViewController.m
+++ b/Example/SDWebImageFLIFCoder/SDViewController.m
@@ -32,7 +32,7 @@
     [self.view addSubview:imageView1];
     [self.view addSubview:imageView2];
     
-    [imageView1 sd_setImageWithURL:staticFLIFURL completed:^(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {
+    [imageView1 sd_setImageWithURL:staticFLIFURL placeholderImage:nil options:SDWebImageProgressiveLoad completed:^(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {
         if (image) {
             NSLog(@"Static FLIF load success");
             dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{

--- a/SDWebImageFLIFCoder/Classes/SDImageFLIFCoder.h
+++ b/SDWebImageFLIFCoder/Classes/SDImageFLIFCoder.h
@@ -11,7 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 static const SDImageFormat SDImageFormatFLIF = 14;
 
-@interface SDImageFLIFCoder : NSObject <SDImageCoder>
+@interface SDImageFLIFCoder : NSObject <SDProgressiveImageCoder>
 
 @property (nonatomic, class, readonly, nonnull) SDImageFLIFCoder *sharedCoder;
 


### PR DESCRIPTION
Since libflif, is pround of that progressive decoding feature, for bandwith and progressive decoding for large images. We can use that to support the progressive decoding protocol.

> Progressive and lossless
> FLIF is lossless, but can still be used in low-bandwidth situations, since only the first part of a file is needed for a reasonable preview of the image.

The code is not hard. We can test with the demo with `SDWebImageProgressiveLoad` option.

One issue is that it will generate a annoyed console log, but since it's a pre-built version and does not hard for performance, currently we just ignore that.