### PR TITLE
Fix the encoding compatibility for CMYK image

### DIFF
--- a/SDWebImageFLIFCoder/Classes/SDImageFLIFCoder.m
+++ b/SDWebImageFLIFCoder/Classes/SDImageFLIFCoder.m
@@ -374,7 +374,8 @@ static void FreeImageData(void *info, const void *data, size_t size) {
         .bitsPerComponent = (uint32_t)CGImageGetBitsPerComponent(imageRef),
         .bitsPerPixel = (uint32_t)CGImageGetBitsPerPixel(imageRef),
         .colorSpace = CGImageGetColorSpace(imageRef),
-        .bitmapInfo = bitmapInfo
+        .bitmapInfo = bitmapInfo,
+        .renderingIntent = CGImageGetRenderingIntent(imageRef)
     };
     vImage_CGImageFormat destFormat = {
         .bitsPerComponent = 8,


### PR DESCRIPTION
This is the same as https://github.com/SDWebImage/SDWebImageWebPCoder/pull/53